### PR TITLE
Revert change for filtering http headers from Instana Span

### DIFF
--- a/SpanConverter.php
+++ b/SpanConverter.php
@@ -134,9 +134,6 @@ class SpanConverter implements SpanConverterInterface
         }
 
         self::unsetEmpty($instanaSpan['data']);
-        if (empty($instanaSpan['data'])) {
-            unset($instanaSpan['data']);
-        }
 
         return $instanaSpan;
     }

--- a/SpanConverter.php
+++ b/SpanConverter.php
@@ -133,18 +133,10 @@ class SpanConverter implements SpanConverterInterface
             self::setOrAppend('otel', $instanaSpan['data']['sdk']['custom']['tags'], array(self::OTEL_KEY_DROPPED_LINKS_COUNT => $span->getTotalDroppedLinks()));
         }
 
-        if (array_key_exists('attributes', $instanaSpan['data']['sdk']['custom']['tags'])) {
-            $keys = array_filter($instanaSpan['data']['sdk']['custom']['tags']['attributes'], function ($k) {
-                return str_contains($k, 'http.request.header');
-            }, ARRAY_FILTER_USE_KEY);
-            $keys += array_filter($instanaSpan['data']['sdk']['custom']['tags']['attributes'], function ($k) {
-                return str_contains($k, 'http.response.header');
-            }, ARRAY_FILTER_USE_KEY);
-            foreach ($keys as $k => $v) {
-                unset($instanaSpan['data']['sdk']['custom']['tags']['attributes'][$k]);
-            }
-        }
         self::unsetEmpty($instanaSpan['data']);
+        if (empty($instanaSpan['data'])) {
+            unset($instanaSpan['data']);
+        }
 
         return $instanaSpan;
     }


### PR DESCRIPTION
 
**Artifcats:**
[JIRA](https://jsw.ibm.com/browse/INSTA-23447)

**Change description :**
This PR removes the filtering of http headers from Instana Span.

**Why:**
Instana php exporter shouldn't parse custom http headers and secrets from url.full explicitly.
mostly , Opentelemetry auto instrumented library supports  custom header capturing by environment variables or ini settings .
for example:
Curl supports custom http header capturing by following variables defined:
OTEL_PHP_INSTRUMENTATION_HTTP_RESPONSE_HEADERS=content-type,server OTEL_PHP_INSTRUMENTATION_HTTP_REQUEST_HEADERS=host,accept
PSR-18 supports custom http headers according to INI setting:
otel.instrumentation.http.request_headers
otel.instrumentation.http.response_headers
 Spec doc: 
 https://opentelemetry.io/docs/specs/semconv/attributes-registry/http/
http.request.header: Instrumentations SHOULD require an explicit configuration of which headers are to be captured.
Slapk thread:
https://instana.slack.com/archives/GBS2G15GD/p1740588844925229
Similar for url redactions :
https://opentelemetry.io/docs/specs/semconv/url/url/

