### PR TITLE
Try to reannounce on failure to send payload

### DIFF
--- a/InstanaTransport.php
+++ b/InstanaTransport.php
@@ -111,7 +111,7 @@ class InstanaTransport implements TransportInterface
         }
 
         if (is_null($this->agent_uuid) || is_null($this->pid)) {
-            throw new Exception('Failed announcement in transport');
+            throw new Exception('Failed announcement in transport. Missing pid or uuid from agent');
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Instana exporter for OpenTelemetry.
 
 ## Documentation
 
-https://www.ibm.com/docs/en/instana-observability/current?topic=opentelemetry-php-exporter
+https://www.ibm.com/docs/en/instana-observability/current?topic=php-opentelemetry-exporter
 
 ## Installing via Composer
 

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Instana\\Test\\Util\\": "./test/util"
+            "Instana\\Test\\Util\\": "./test/Util"
         }
     },
     "extra": {


### PR DESCRIPTION
When running tests locally, I needed to change the autoload path in composer.json to match the casing of `test/Util`. Not sure if it's case sensitive in general?